### PR TITLE
Override MpPhPortableUtil >> timestampFromSeconds: seconds nanos: nanoSeconds. 

### DIFF
--- a/repository/MessagePack-Pharo-Core.package/MpPhPortableUtil.class/instance/timestampFromSeconds.nanos..st
+++ b/repository/MessagePack-Pharo-Core.package/MpPhPortableUtil.class/instance/timestampFromSeconds.nanos..st
@@ -1,0 +1,6 @@
+actions
+timestampFromSeconds: seconds nanos: nanoSeconds
+	| ts |
+	ts := DateAndTime fromSeconds: seconds + 2177452800 offset: 0.
+	nanoSeconds > 0 ifTrue: [ ts setNanoSeconds: nanoSeconds].
+	^ts


### PR DESCRIPTION
This implementation no longer works in Squeak 5+.