### PR TITLE
Changed MpSqPortableUtil >> timestampFromSeconds: seconds nanos: Seconds

### DIFF
--- a/repository/MessagePack-Squeak-Core.package/DateAndTime.extension/instance/setNanoSeconds..st
+++ b/repository/MessagePack-Squeak-Core.package/DateAndTime.extension/instance/setNanoSeconds..st
@@ -1,3 +1,0 @@
-*MessagePack-Squeak-Core
-setNanoSeconds: nanoSeconds
-	nanos := nanoSeconds

--- a/repository/MessagePack-Squeak-Core.package/DateAndTime.extension/properties.json
+++ b/repository/MessagePack-Squeak-Core.package/DateAndTime.extension/properties.json
@@ -1,3 +1,0 @@
-{
-	"name" : "DateAndTime"
-}

--- a/repository/MessagePack-Squeak-Core.package/MpSqPortableUtil.class/instance/timestampFromSeconds.nanos..st
+++ b/repository/MessagePack-Squeak-Core.package/MpSqPortableUtil.class/instance/timestampFromSeconds.nanos..st
@@ -1,6 +1,6 @@
 actions
 timestampFromSeconds: seconds nanos: nanoSeconds
-	| ts |
-	ts := DateAndTime fromSeconds: seconds + 2177452800 offset: 0.
-	nanoSeconds > 0 ifTrue: [ ts setNanoSeconds: nanoSeconds].
+	| microseconds ts |
+	microseconds := (seconds * 1000000) + (nanoSeconds * 0.001).
+	ts := DateAndTime utcMicroseconds: microseconds offset: 0.
 	^ts


### PR DESCRIPTION
Fixes related to timestamp decoding in Squeak 5+.

Since DateAndTime only supports microseconds precision in Squeak 5+, nanosecond values are mostly ignored.