### PR TITLE
Update main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        smalltalk: [Pharo64-11, Pharo64-12]
+        smalltalk: [Pharo64-11, Pharo64-12, Pharo64-13]
         experimental: [false]
     continue-on-error: ${{ matrix.experimental }}
     name: ${{ matrix.smalltalk }}


### PR DESCRIPTION
This pull request updates the CI workflow configuration to include a new Smalltalk version in the test matrix.

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L11-R11): Added `Pharo64-13` to the `smalltalk` matrix, ensuring tests are run against the latest Smalltalk version.